### PR TITLE
Fix testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.8"
   - "3.8-dev"
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt -r tests/requirements.txt
 script:
   - python3 -m pytest
 branches:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+pytest-asyncio==0.14.0


### PR DESCRIPTION
`pytest-asyncio` package was missing from test requirements. Only warnings were raised, so async tests were not run properly on Travis CI.