### PR TITLE
Fix limit parameter for random

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,4 +1,11 @@
+.. currentmodule:: pyud
+
 Changelog
 =========
 
 This page shows a complete summary of changes and fixes made in each version.
+
+v1.0.1
+------
+
+- Fix :paramref:`Client.random.limit` and :paramref:`AsyncClient.random.limit` parameters so that values greater than 10 are properly considered. 

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -127,7 +127,9 @@ class Client(ClientBase):
             :paramref:`~Client.random.limit` to be higher than 10,
             and make use of validation to avoid this.
         """
-        definitions = self._fetch_definitions(RANDOM_URL)
+        definitions = []
+        for _ in range(limit // 10 + 1):
+            definitions += self._fetch_definitions(RANDOM_URL)
 
         return definitions[:limit]
 
@@ -185,6 +187,8 @@ class AsyncClient(ClientBase):
 
             See :meth:`Client.random` for warning.
         """
-        definitions = await self._fetch_definitions(RANDOM_URL)
+        definitions = []
+        for _ in range(limit // 10 + 1):
+            definitions += await self._fetch_definitions(RANDOM_URL)
 
         return definitions[:limit]

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -35,4 +35,8 @@ class TestAsyncClient:
     async def test_client_random_limit(self, client):
         assert len(await client.random(limit=3)) == 3
         assert len(await client.random(limit=10)) == 10
-        assert len(await client.random(limit=43)) == 10
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail
+    async def test_client_random_limit_gt_10(self, client):
+        assert len(await client.random(limit=43)) == 43

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -37,6 +37,5 @@ class TestAsyncClient:
         assert len(await client.random(limit=10)) == 10
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail
     async def test_client_random_limit_gt_10(self, client):
         assert len(await client.random(limit=43)) == 43

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,4 +30,7 @@ class TestClient:
     def test_client_random_limit(self, client):
         assert len(client.random(limit=3)) == 3
         assert len(client.random(limit=10)) == 10
-        assert len(client.random(limit=43)) == 10
+
+    @pytest.mark.xfail
+    def test_client_random_limit_gt_10(self, client):
+        assert len(client.random(limit=43)) == 43

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,6 +31,5 @@ class TestClient:
         assert len(client.random(limit=3)) == 3
         assert len(client.random(limit=10)) == 10
 
-    @pytest.mark.xfail
     def test_client_random_limit_gt_10(self, client):
         assert len(client.random(limit=43)) == 43


### PR DESCRIPTION
Fixes `AsyncClient.random` and `Client.random` such that the `limit` parameter is properly considered for `limit > 10`