### PR TITLE
Verify compatibility with Python 3.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5.3"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -114,7 +114,7 @@ class Definition:
         permalink: str,
         sound_urls: List[str],
         written_on: str,
-        **attrs: Any,
+        **attrs: Any
     ):
         """
         Instantiates an instance of an Urban Dictionary definition

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 """
 Source:
 
-https://docs.pytest.org/en/stable/example/simple.html?highlight=incremental#incremental-testing-test-steps
+https://docs.pytest.org/en/stable/example/simple.html?#incremental-testing-test-steps
 """
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,12 @@ Source:
 
 https://docs.pytest.org/en/stable/example/simple.html?highlight=incremental#incremental-testing-test-steps
 """
-from typing import Dict, Tuple
 
 import pytest
 
 # store history of failures per test class name
 # and per index in parametrize (if parametrize used)
-_test_failed_incremental: Dict[str, Dict[Tuple[int, ...], str]] = {}
+_test_failed_incremental = {}
 
 
 def pytest_runtest_makereport(item, call):


### PR DESCRIPTION
At the moment, `pyud` is not verified to be compatible with Python >= 3.5.3, < 3.6. This is because a type hint in `tests/conftest.py` has a variable type hint, not supported in Python 3.5. The actual module code does not contain variable type hints, and so should run on the aforementioned versions.

This PR removes the type hint to allow testing.

**Edit:** turns out trailing commas in parameter lists where `*` or `**` are not supported in Python 3.5. These have been removed.