### PR TITLE
Add references

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 79
 select = C,E,F,W,B,B950
-ignore = E203, E501, W503
+ignore = E203, E501, W503, BLK100

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 79
 select = C,E,F,W,B,B950
-ignore = E203, E501, W503, BLK100
+ignore = E203, E501, W503

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -36,3 +36,15 @@ Definition
 
 .. autoclass:: Definition
     :members:
+
+Reference
+---------
+
+.. autoclass:: Reference
+    :members:
+
+AsyncReference
+--------------
+
+.. autoclass:: AsyncReference
+    :members:

--- a/pyud/__init__.py
+++ b/pyud/__init__.py
@@ -23,6 +23,7 @@ from collections import namedtuple
 
 from .definition import Definition
 from .client import AsyncClient, Client
+from .reference import AsyncReference, Reference
 
 __author__ = "William Lee"
 __version__ = "1.0.1rc1"

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -25,7 +25,7 @@ from urllib import request
 
 import aiohttp
 
-from .definition import Definition
+from . import definition
 
 BASE_URL = "https://api.urbandictionary.com/v0/"
 DEFINE_BY_TERM_URL = BASE_URL + "define?term={}"
@@ -40,7 +40,7 @@ class ClientBase:
 
     def _parse_definitions_from_json(
         self, data: Union[str, bytes, bytearray]
-    ) -> Optional[List[Definition]]:
+    ) -> Optional[List['definition.Definition']]:
         """
         Returns a list of Definitions from JSON
 
@@ -63,7 +63,7 @@ class ClientBase:
 
         for dictionary in definitions_list:
             try:
-                definitions += [Definition(**dictionary)]
+                definitions += [definition.Definition(**dictionary)]
             except TypeError:
                 pass
 
@@ -75,7 +75,9 @@ class Client(ClientBase):
     Synchronous client for the Urban Dictionary API
     """
 
-    def _fetch_definitions(self, url: str) -> Optional[List[Definition]]:
+    def _fetch_definitions(
+        self, url: str
+    ) -> Optional[List['definition.Definition']]:
         """
         Fetch definitions from the API url given
         """
@@ -84,7 +86,7 @@ class Client(ClientBase):
                 response.read().decode('utf-8')
             )
 
-    def define(self, term: str) -> Optional[List[Definition]]:
+    def define(self, term: str) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term
 
         :param term: The term to find definitions for
@@ -94,7 +96,7 @@ class Client(ClientBase):
         """
         return self._fetch_definitions(DEFINE_BY_TERM_URL.format(term))
 
-    def from_id(self, defid: int) -> Optional[Definition]:
+    def from_id(self, defid: int) -> Optional['definition.Definition']:
         """Finds a definition by ID
 
         :param defid: The ID of the definition
@@ -106,7 +108,7 @@ class Client(ClientBase):
 
         return definitions[0] if definitions else None
 
-    def random(self, *, limit: int = 10) -> List[Definition]:
+    def random(self, *, limit: int = 10) -> List['definition.Definition']:
         """Returns a random list of definitions
 
         :param limit: The number of definitions to return, defaults to 10
@@ -126,7 +128,9 @@ class AsyncClient(ClientBase):
     Asynchronous client for the Urban Dictionary API
     """
 
-    async def _fetch_definitions(self, url: str) -> Optional[List[Definition]]:
+    async def _fetch_definitions(
+        self, url: str
+    ) -> Optional[List['definition.Definition']]:
         """
         Fetch definitions from the API url given
         """
@@ -134,7 +138,9 @@ class AsyncClient(ClientBase):
             async with session.get(url) as response:  # nosec
                 return self._parse_definitions_from_json(await response.text())
 
-    async def define(self, term: str) -> Optional[List[Definition]]:
+    async def define(
+        self, term: str
+    ) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term asynchronously
 
         :param term: The term to find definitions for
@@ -144,7 +150,7 @@ class AsyncClient(ClientBase):
         """
         return await self._fetch_definitions(DEFINE_BY_TERM_URL.format(term))
 
-    async def from_id(self, defid: int) -> Optional[Definition]:
+    async def from_id(self, defid: int) -> Optional['definition.Definition']:
         """Finds a definition by ID asynchronously
 
         :param defid: The ID of the definition
@@ -158,7 +164,9 @@ class AsyncClient(ClientBase):
 
         return definitions[0] if definitions else None
 
-    async def random(self, *, limit: int = 10) -> List[Definition]:
+    async def random(
+        self, *, limit: int = 10
+    ) -> List['definition.Definition']:
         """Returns a random list of definitions
 
         :param limit: The number of definitions to return, defaults to 10

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -63,7 +63,7 @@ class ClientBase:
 
         for dictionary in definitions_list:
             try:
-                definitions += [definition.Definition(**dictionary)]
+                definitions += [definition.Definition(self, **dictionary)]
             except TypeError:
                 pass
 

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -180,6 +180,4 @@ class Definition:
                     if isinstance(self._client, client.Client)
                     else reference.AsyncReference
                 )
-                self.references += [
-                    ref_type(self._client, match.group('ref'))
-                ]
+                self.references += [ref_type(self._client, match.group('ref'))]

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -25,7 +25,7 @@ from typing import Any, List, Union
 
 from . import client, reference
 
-REFERENCE_REGEX = re.compile(r"\[(?P<ref>\S+)\]")
+REFERENCE_REGEX = re.compile(r"\[(?P<ref>.+?)\]")
 
 
 class Definition:

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -20,7 +20,9 @@ along with pyud.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from datetime import datetime as dt
-from typing import Any, List
+from typing import Any, List, Union
+
+from . import client
 
 
 class Definition:
@@ -102,6 +104,7 @@ class Definition:
 
     def __init__(
         self,
+        client: Union['client.AsyncClient', 'client.Client'],
         *,
         defid: int,
         word: str,
@@ -118,6 +121,7 @@ class Definition:
         """
         Instantiates an instance of an Urban Dictionary definition
         """
+        self._client = client
         self.defid = defid
         self.word = word
         self.definition = definition

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -54,7 +54,9 @@ class Definition:
 
         A list of references to other terms found in the :attr:`definition`
         and :attr:`example` attributes. References found within these strings
-        are enclosed in squares brackets. For example, this::
+        are enclosed in squares brackets. For example, this
+
+        .. code-block:: text
 
             [This] is enclosed in [square brackets]
 

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -50,6 +50,18 @@ class Definition:
         The :attr:`current_vote` attribute is not included
         as a required attribute, as it does not contain any meaningful information.
 
+    .. attribute:: references
+
+        A list of references to other terms found in the :attr:`definition`
+        and :attr:`example` attributes. These references are found enclosed
+        in square brackets, ``[like this]``, and are extracted into reference objects.
+
+        The class of the reference objects is :class:`Reference`
+        if you have used :class:`Client` to obtain definitions,
+        and :class:`AsyncReference` if you have used :class:`AsyncClient`.
+
+        :type: Union[List[Reference], List[AsyncReference]]
+
     .. attribute:: defid
 
         The ID of the definition

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -165,13 +165,14 @@ class Definition:
         self.references = []
         for text in self.definition, self.example:
             matches = REFERENCE_REGEX.finditer(text)
-            if matches:
-                for match in matches:
-                    ref_type = (
-                        reference.Reference
-                        if isinstance(self._client, client.Client)
-                        else reference.AsyncReference
-                    )
-                    self.references += [
-                        ref_type(self._client, match.group('ref'))
-                    ]
+            if not matches:
+                continue
+            for match in matches:
+                ref_type = (
+                    reference.Reference
+                    if isinstance(self._client, client.Client)
+                    else reference.AsyncReference
+                )
+                self.references += [
+                    ref_type(self._client, match.group('ref'))
+                ]

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -53,8 +53,13 @@ class Definition:
     .. attribute:: references
 
         A list of references to other terms found in the :attr:`definition`
-        and :attr:`example` attributes. These references are found enclosed
-        in square brackets, ``[like this]``, and are extracted into reference objects.
+        and :attr:`example` attributes. References found within these strings
+        are enclosed in squares brackets. For example, this::
+
+            [This] is enclosed in [square brackets]
+
+        has references to *this* and **square brackets**.
+        References are extracted to reference objects
 
         The class of the reference objects is :class:`Reference`
         if you have used :class:`Client` to obtain definitions,

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -18,3 +18,23 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with pyud.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+from typing import List
+
+from . import client, definition
+
+
+class ReferenceBase:
+    def __init__(self, client: 'client.Client', word: str):
+        self.client = client
+        self.word = word
+
+
+class Reference(ReferenceBase):
+    def define(self) -> List['definition.Definition']:
+        return self.client.define(self.word)
+
+
+class AsyncReference(ReferenceBase):
+    async def define(self) -> List['definition.Definition']:
+        return await self.client.define(self.word)

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -50,6 +50,7 @@ class Reference(ReferenceBase):
 
         :type: str
     """
+
     def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference
 
@@ -73,6 +74,7 @@ class AsyncReference(ReferenceBase):
 
         :type: str
     """
+
     async def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference asynchronously
 

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -19,12 +19,20 @@ You should have received a copy of the GNU General Public License
 along with pyud.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 from . import client, definition
 
 
 class ReferenceBase:
+    """
+    Represents a reference in an Urban Dictionary definition.
+
+    Instances of this class should not obtained directly, and should instead be obtained
+    by accessing the :paramref:`~Definition.references` attribute
+    on an instance of :class:`Definition`.
+    """
+
     def __init__(
         self, client: Union['client.Client', 'client.AsyncClient'], word: str
     ):
@@ -33,10 +41,20 @@ class ReferenceBase:
 
 
 class Reference(ReferenceBase):
-    def define(self) -> List['definition.Definition']:
+    def define(self) -> Optional[List['definition.Definition']]:
+        """Returns definitions for the reference
+
+        :return: A list of definitions, or :obj:`None` if none are found
+        :rtype: Optional[List[Definition]]
+        """
         return self.client.define(self.word)
 
 
 class AsyncReference(ReferenceBase):
-    async def define(self) -> List['definition.Definition']:
+    async def define(self) -> Optional[List['definition.Definition']]:
+        """Returns definitions for the reference asynchronously
+
+        :return: A list of definitions, or :obj:`None` if none are found
+        :rtype: Optional[List[Definition]]
+        """
         return await self.client.define(self.word)

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -44,7 +44,7 @@ class Reference(ReferenceBase):
     def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference
 
-        :return: A list of definitions, or :obj:`None` if none are found
+        :return: A list of definitions, or :data:`None` if none are found
         :rtype: Optional[List[Definition]]
         """
         return self.client.define(self.word)
@@ -54,7 +54,7 @@ class AsyncReference(ReferenceBase):
     async def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference asynchronously
 
-        :return: A list of definitions, or :obj:`None` if none are found
+        :return: A list of definitions, or :data:`None` if none are found
         :rtype: Optional[List[Definition]]
         """
         return await self.client.define(self.word)

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -19,13 +19,15 @@ You should have received a copy of the GNU General Public License
 along with pyud.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import List
+from typing import List, Union
 
 from . import client, definition
 
 
 class ReferenceBase:
-    def __init__(self, client: 'client.Client', word: str):
+    def __init__(
+        self, client: Union['client.Client', 'client.AsyncClient'], word: str
+    ):
         self.client = client
         self.word = word
 

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -44,6 +44,11 @@ class Reference(ReferenceBase):
     Instances of this class should not obtained directly, and should instead be obtained
     by accessing the :paramref:`~Definition.references` attribute
     on an instance of :class:`Definition`.
+
+    .. attribute:: word
+        The word or phrase of the reference
+
+        :type: str
     """
     def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference
@@ -62,6 +67,11 @@ class AsyncReference(ReferenceBase):
     Instances of this class should not obtained directly, and should instead be obtained
     by accessing the :paramref:`~Definition.references` attribute
     on an instance of :class:`Definition`.
+
+    .. attribute:: word
+        The word or phrase of the reference
+
+        :type: str
     """
     async def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference asynchronously

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -27,10 +27,6 @@ from . import client, definition
 class ReferenceBase:
     """
     Represents a reference in an Urban Dictionary definition.
-
-    Instances of this class should not obtained directly, and should instead be obtained
-    by accessing the :paramref:`~Definition.references` attribute
-    on an instance of :class:`Definition`.
     """
 
     def __init__(
@@ -41,6 +37,14 @@ class ReferenceBase:
 
 
 class Reference(ReferenceBase):
+    """
+    The class of references in :paramref:`Definition.references`
+    when :class:`Client` is used to obtain those definitions
+
+    Instances of this class should not obtained directly, and should instead be obtained
+    by accessing the :paramref:`~Definition.references` attribute
+    on an instance of :class:`Definition`.
+    """
     def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference
 
@@ -51,6 +55,14 @@ class Reference(ReferenceBase):
 
 
 class AsyncReference(ReferenceBase):
+    """
+    The class of references in :paramref:`Definition.references`
+    when :class:`AsyncClient` is used to obtain those definitions
+
+    Instances of this class should not obtained directly, and should instead be obtained
+    by accessing the :paramref:`~Definition.references` attribute
+    on an instance of :class:`Definition`.
+    """
     async def define(self) -> Optional[List['definition.Definition']]:
         """Returns definitions for the reference asynchronously
 

--- a/pyud/reference.py
+++ b/pyud/reference.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+pyud.reference
+Copyright (c) 2020 William Lee
+
+This file is part of pyud.
+
+pyud is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pyud is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pyud.  If not, see <https://www.gnu.org/licenses/>.
+"""

--- a/tests/test_async_reference.py
+++ b/tests/test_async_reference.py
@@ -4,6 +4,20 @@ import pytest
 import pyud
 
 
+@pytest.fixture
+def reference():
+    ud = pyud.AsyncClient()
+    return pyud.AsyncReference(ud, "hello")
+
+
 @pytest.mark.incremental
 class TestAsyncReference:
-    pass
+    @pytest.mark.asyncio
+    async def test_reference_word(self, reference):
+        assert reference.word == "hello"
+
+    @pytest.mark.asyncio
+    async def test_reference_define(self, reference):
+        definitions = await reference.define()
+        for definition in definitions:
+            assert definition.word.lower() == "hello"

--- a/tests/test_async_reference.py
+++ b/tests/test_async_reference.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import pyud
+
+
+@pytest.mark.incremental
+class TestAsyncReference:
+    pass

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -33,33 +33,38 @@ EXTRA_ATTRIBUTES = {
 }
 
 
-def test_complete_definition():
-    assert pyud.Definition(**DATA) is not None
+@pytest.fixture
+def client():
+    return pyud.Client()
 
 
-def test_incomplete_definition():
+def test_complete_definition(client):
+    assert pyud.Definition(client, **DATA) is not None
+
+
+def test_incomplete_definition(client):
     for key in DATA:
         incomplete_data = DATA.copy()
         del incomplete_data[key]
 
         with pytest.raises(TypeError):
-            pyud.Definition(**incomplete_data)
+            pyud.Definition(client, **incomplete_data)
 
 
-def test_incorrect_date_format():
+def test_incorrect_date_format(client):
     for date in INCORRECT_DATES:
         data = DATA.copy()
         data["written_on"] = date
 
         with pytest.raises(ValueError):
-            pyud.Definition(**data)
+            pyud.Definition(client, **data)
 
 
-def test_excess_attributes():
+def test_excess_attributes(client):
     data = DATA.copy()
     data = dict(data, **EXTRA_ATTRIBUTES)
 
-    definition = pyud.Definition(**data)
+    definition = pyud.Definition(client, **data)
 
     for key, value in EXTRA_ATTRIBUTES.items():
         assert getattr(definition, key) == value

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import pyud
+
+
+@pytest.mark.incremental
+class TestReference:
+    pass

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -4,6 +4,18 @@ import pytest
 import pyud
 
 
+@pytest.fixture
+def reference():
+    ud = pyud.Client()
+    return pyud.Reference(ud, "hello")
+
+
 @pytest.mark.incremental
 class TestReference:
-    pass
+    def test_reference_word(self, reference):
+        assert reference.word == "hello"
+
+    def test_reference_define(self, reference):
+        definitions = reference.define()
+        for definition in definitions:
+            assert definition.word.lower() == "hello"


### PR DESCRIPTION
Adds references to definition objects

- `Definition.references` contains a list of references
- `Reference` for sync, `AsyncReference` for async
- `word` attribute for term, `define()` method for defining the reference