### PR TITLE
Allow `define()` to work with multiple-word terms

### DIFF
--- a/pyud/client.py
+++ b/pyud/client.py
@@ -22,6 +22,7 @@ along with pyud.  If not, see <https://www.gnu.org/licenses/>.
 import json
 from typing import List, Optional, Union
 from urllib import request
+from urllib.parse import quote as url_quote
 
 import aiohttp
 
@@ -92,7 +93,9 @@ class Client(ClientBase):
         :return: A list of definitions or :data:`None` if not found
         :rtype: Optional[List[Definition]]
         """
-        return self._fetch_definitions(DEFINE_BY_TERM_URL.format(term))
+        return self._fetch_definitions(
+            DEFINE_BY_TERM_URL.format(url_quote(term))
+        )
 
     def from_id(self, defid: int) -> Optional[Definition]:
         """Finds a definition by ID
@@ -142,7 +145,9 @@ class AsyncClient(ClientBase):
         :return: A list of definitions or :data:`None` if not found
         :rtype: Optional[List[Definition]]
         """
-        return await self._fetch_definitions(DEFINE_BY_TERM_URL.format(term))
+        return await self._fetch_definitions(
+            DEFINE_BY_TERM_URL.format(url_quote(term))
+        )
 
     async def from_id(self, defid: int) -> Optional[Definition]:
         """Finds a definition by ID asynchronously

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -18,6 +18,7 @@ class TestAsyncClient:
     @pytest.mark.asyncio
     async def test_client_define(self, client):
         assert await client.define('hello')
+        assert await client.define('something real')
         assert await client.define('skadhfujahkduikfbresfvkayjfsrvued') is None
 
     @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ class TestClient:
 
     def test_client_define(self, client):
         assert client.define('hello')
+        assert client.define('something real')
         assert client.define('skadhfujahkduikfbresfvkayjfsrvued') is None
 
     def test_client_from_id(self, client):


### PR DESCRIPTION
Fixes #25 