### PR TITLE
Add removal of square brackets for references from text

### DIFF
--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -177,7 +177,7 @@ class Definition:
     def _find_references(self):
         ref_type = (
             reference.Reference
-            if isinstance(self._client, client.Client)
+            if isinstance(self.client, client.Client)
             else reference.AsyncReference
         )
         self.references = []

--- a/pyud/definition.py
+++ b/pyud/definition.py
@@ -169,18 +169,32 @@ class Definition:
         self._find_references()
 
     def _find_references(self):
+        ref_type = (
+            reference.Reference
+            if isinstance(self._client, client.Client)
+            else reference.AsyncReference
+        )
         self.references = []
-        for text in self.definition, self.example:
+        for attr in ('definition', 'example'):
+            text = getattr(self, attr)
+
             matches = REFERENCE_REGEX.finditer(text)
             if not matches:
                 continue
+
+            offset = 0
             for match in matches:
-                ref_type = (
-                    reference.Reference
-                    if isinstance(self._client, client.Client)
-                    else reference.AsyncReference
+                term = match.group('ref')
+                self.references += [ref_type(self._client, term)]
+                text = (
+                    text[: match.start() - offset]
+                    + term
+                    + text[match.end() - offset :]
                 )
-                self.references += [ref_type(self._client, match.group('ref'))]
+
+                offset += 2
+
+            setattr(self, attr, text)
 
     def __str__(self):
         return (


### PR DESCRIPTION
- Removes square bracket pairs, corresponding to references to other terms, in the `definition` and `example` attributes of `Definition`