### PR TITLE
Add page limit and generator

### DIFF
--- a/pyud/client.py
+++ b/pyud/client.py
@@ -96,10 +96,13 @@ class Client(ClientBase):
     def define(
         self, term: str, page: int = 1
     ) -> Optional[List['definition.Definition']]:
-        """Finds definitions for a given term
+        """Finds definitions for a given term from a given page,
+        up to a maximum of 10 definitions.
 
         :param term: The term to find definitions for
         :type term: str
+        :param page: The page of the definitions to return, defaults to 1
+        :type page: int
         :return: A list of definitions or :data:`None` if not found
         :rtype: Optional[List[Definition]]
         """
@@ -152,10 +155,13 @@ class AsyncClient(ClientBase):
     async def define(
         self, term: str, page: int = 1
     ) -> Optional[List['definition.Definition']]:
-        """Finds definitions for a given term asynchronously
+        """Finds definitions for a given term from a given page asynchronously,
+        up to a maximum of 10 definitions.
 
         :param term: The term to find definitions for
         :type term: str
+        :param page: The page of the definitions to return, defaults to 1.
+        :type page: int
         :return: A list of definitions or :data:`None` if not found
         :rtype: Optional[List[Definition]]
         """

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -202,7 +202,7 @@ class AsyncClient(ClientBase):
         self, term: str, limit: Optional[int] = None
     ) -> AsyncGenerator['definition.Definition', None]:
         """Finds definitions for a given term up to a certain number of definitions,
-        returning a generator.
+        returning an asynchronous generator.
 
         :param term: The term to find definitions for
         :type term: str

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -29,7 +29,7 @@ import aiohttp
 from . import definition
 
 BASE_URL = "https://api.urbandictionary.com/v0/"
-DEFINE_BY_TERM_URL = BASE_URL + "define?term={}"
+DEFINE_BY_TERM_URL = BASE_URL + "define?term={}&page={}"
 DEFINE_BY_ID_URL = BASE_URL + "define?defid={}"
 RANDOM_URL = BASE_URL + "random"
 
@@ -93,7 +93,9 @@ class Client(ClientBase):
                 response.read().decode('utf-8')
             )
 
-    def define(self, term: str) -> Optional[List['definition.Definition']]:
+    def define(
+        self, term: str, page: int = 1
+    ) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term
 
         :param term: The term to find definitions for
@@ -102,7 +104,7 @@ class Client(ClientBase):
         :rtype: Optional[List[Definition]]
         """
         return self._fetch_definitions(
-            DEFINE_BY_TERM_URL.format(url_quote(term))
+            DEFINE_BY_TERM_URL.format(url_quote(term), page)
         )
 
     def from_id(self, defid: int) -> Optional['definition.Definition']:
@@ -148,7 +150,7 @@ class AsyncClient(ClientBase):
                 return self._parse_definitions_from_json(await response.text())
 
     async def define(
-        self, term: str
+        self, term: str, page: int = 1
     ) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term asynchronously
 
@@ -158,7 +160,7 @@ class AsyncClient(ClientBase):
         :rtype: Optional[List[Definition]]
         """
         return await self._fetch_definitions(
-            DEFINE_BY_TERM_URL.format(url_quote(term))
+            DEFINE_BY_TERM_URL.format(url_quote(term), page)
         )
 
     async def from_id(self, defid: int) -> Optional['definition.Definition']:

--- a/pyud/client.py
+++ b/pyud/client.py
@@ -94,7 +94,7 @@ class Client(ClientBase):
             )
 
     def define(
-        self, term: str, page: int = 1
+        self, term: str, *, page: int = 1
     ) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term from a given page,
         up to a maximum of 10 definitions.
@@ -153,7 +153,7 @@ class AsyncClient(ClientBase):
                 return self._parse_definitions_from_json(await response.text())
 
     async def define(
-        self, term: str, page: int = 1
+        self, term: str, *, page: int = 1
     ) -> Optional[List['definition.Definition']]:
         """Finds definitions for a given term from a given page asynchronously,
         up to a maximum of 10 definitions.


### PR DESCRIPTION
# Rationale

- The API has been found to support a `page` parameter. This is only useful for the use of fetching definitions for a certain term from the API.

# Changes

- Adds a `page` parameter to the `define()` method/coroutinue, defaults to 1 for backwards-compatibility
- Adds `define_iter()` method/coroutine for returning all definitions as a generator, with an optional `limit` parameter.